### PR TITLE
Doc link updates 

### DIFF
--- a/gateway/doc/p_clientlogging_js.md
+++ b/gateway/doc/p_clientlogging_js.md
@@ -68,6 +68,6 @@ To Enable the JavaScript Client Logs
 See Also
 --------
 
-To learn how to build clients using the Kaazing client libraries, see the Kaazing client developer documentation in the **For Developer's** section of the [documentation](../index.md) page.
+To learn how to build clients using the Kaazing client libraries, see the Kaazing client developer documentation in the **For Developer's** section of the [documentation](https://github.com/kaazing/gateway/blob/develop/doc/index.md) page.
 
 

--- a/gateway/doc/p_dev_js_eventsource.md
+++ b/gateway/doc/p_dev_js_eventsource.md
@@ -9,7 +9,7 @@ Use the JavaScript EventSource API
 
 This section describes how you can use the `EventSource` API provided by the Kaazing JavaScript client library. This API allows you to take advantage of the Server-Sent Events standard as described in the [HTML5 specification](http://www.w3.org/html/wg/html5/#server-sent-events). For example, you can create a JavaScript client that uses the JavaScript HTML5 Communications client library to receive streaming data from a news feed or streaming financial data. The support for Server-Sent Events is provided by the `EventSource` class and its supporting classes.
 
-The following steps show you how to use the `EventSource` API. This example highlights some of the most commonly used `EventSource` methods and is not meant to be an end-to-end tutorial. Refer to the [EventSource API documentation](../apidoc/client/javascript/gateway/EventSource.md) for a complete description of all the available methods.
+The following steps show you how to use the `EventSource` API. This example highlights some of the most commonly used `EventSource` methods and is not meant to be an end-to-end tutorial. Refer to the [EventSource API documentation](http://developer.kaazing.com/documentation/5.0/apidoc/client/javascript/gateway/EventSource.html) for a complete description of all the available methods.
 
 Before You Begin
 ----------------
@@ -55,6 +55,6 @@ Next Step
 See Also
 --------
 
-[EventSource API documentation](../apidoc/client/javascript/gateway/EventSource.md)
+[EventSource API documentation](http://developer.kaazing.com/documentation/5.0/apidoc/client/javascript/gateway/EventSource.html)
 
 

--- a/gateway/doc/p_dev_js_secure.md
+++ b/gateway/doc/p_dev_js_secure.md
@@ -6,7 +6,7 @@ Secure Your JavaScript Client
 =============================
 
 Note: To use the Gateway, a KAAZING client library, or a KAAZING demo, fork the repository from [kaazing.org](http://kaazing.org).
-Before you add security to your clients, follow the steps in [Secure Network Traffic with the Gateway](../security/o_tls.md) and [Configure Authentication and Authorization](../security/o_aaa_config_authentication.md) to set up security on KAAZING Gateway for your client. The authentication and authorization methods configured on the Gateway influence your client security implementation. In this procedure, we provide an example of the most common implementation.
+Before you add security to your clients, follow the steps in [Secure Network Traffic with the Gateway](../security/o_tls.md) and [Configure Authentication and Authorization](https://github.com/kaazing/gateway/blob/develop/doc/security/o_auth_configure.md) to set up security on KAAZING Gateway for your client. The authentication and authorization methods configured on the Gateway influence your client security implementation. In this procedure, we provide an example of the most common implementation.
 
 
 To Secure Your JavaScript Client
@@ -27,7 +27,7 @@ Authenticating your client involves implementing a challenge handler to respond 
 
 A challenge handler is a constructor used in an application to respond to authentication challenges from the Gateway when the application attempts to access a protected resource. Each of the resources protected by the Gateway is configured with a different authentication scheme (for example, Basic, Application Basic, Application Negotiate, or Application Token), and your application requires a challenge handler for each of the schemes that it will encounter or a single challenge handler that will respond to all challenges. Also, you can add a dispatch challenge handler to route challenges to specific challenge handlers according to the URI of the requested resource.
 
-For information about each authentication scheme type, see [Configure the HTTP Challenge Scheme](../security/p_aaa_config_authscheme.md).
+For information about each authentication scheme type, see [Configure the HTTP Challenge Scheme](https://github.com/kaazing/gateway/blob/develop/doc/security/p_authentication_config_http_challenge_scheme.md).
 
 Clients with a single challenge handling strategy for all 401 challenges can simply set a specific challenge handler as the default using `webSocketFactory.setChallengeHandler()`. The following is an example of how to implement a single challenge handler for all challenges:
 


### PR DESCRIPTION
This request contains changes to doc links within the Markdown files. Links are updated to direct to correct path, either by updating the link's filename or by replacing a link with the absolute URL (for cross-repo doc links). These errors originally occurred during Doc migration. Address "fix broken links" in [Deliver documentation to website upon release](https://github.com/kaazing/roadmap/issues/320).
